### PR TITLE
Increase font sizes and bump plugin version to 1.0.2

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -32,7 +32,7 @@
     justify-content: center;
     text-decoration: none;
     color: #333333;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 400;
     transition: all 0.3s ease;
     position: relative;
@@ -141,7 +141,7 @@
 
 /* Label Styles */
 .wpbnp-nav-label {
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 400;
     line-height: 1.2;
     text-align: center;
@@ -539,7 +539,7 @@
     
     .wpbnp-nav-item {
         max-width: 60px;
-        font-size: 11px;
+        font-size: 13px;
     }
     
     .wpbnp-nav-icon {
@@ -549,7 +549,7 @@
     }
     
     .wpbnp-nav-label {
-        font-size: 10px;
+        font-size: 12px;
     }
 }
 
@@ -560,7 +560,7 @@
     
     .wpbnp-nav-item {
         max-width: 50px;
-        font-size: 10px;
+        font-size: 12px;
         padding: 2px;
     }
     
@@ -571,7 +571,7 @@
     }
     
     .wpbnp-nav-label {
-        font-size: 9px;
+        font-size: 11px;
     }
     
     .wpbnp-badge {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -64,7 +64,7 @@ function wpbnp_get_default_settings() {
             'height' => '60',
             'border_radius' => '0',
             'box_shadow' => '0 -2px 8px rgba(0,0,0,0.1)',
-            'font_size' => '12',
+            'font_size' => '14',
             'font_weight' => '400',
             'icon_size' => '20',
             'padding' => '10'

--- a/wp-bottom-navigation-pro.php
+++ b/wp-bottom-navigation-pro.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('WPBNP_VERSION', '1.0.1');
+define('WPBNP_VERSION', '1.0.2');
 define('WPBNP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WPBNP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('WPBNP_PLUGIN_BASENAME', plugin_basename(__FILE__));


### PR DESCRIPTION
Grepped codebase for "font-size.*px"

Let me check what these different font sizes are for:
Read frontend.css

I can see that there are two main font sizes to update:

    .wpbnp-nav-item (line 35): 12px - the overall navigation item text
    .wpbnp-nav-label (line 144): 12px - the label text specifically

Let me also check the default settings in the functions.php file to see if there's a default font size setting:
Grepped codebase for "font_size"

Perfect! I can see there's a font_size setting with a default of 12. Let me update both the default setting and the CSS. First, let me increase the default font size:
Replaced text

Now let me update the CSS to reflect the larger default font size:
Replaced text 2 times

Now let me also check if there are any responsive font sizes that need updating:
Read frontend.css

The 10px font size is for badges, which should remain small. Let me check the responsive breakpoints to see if there are any smaller font sizes for mobile:
Read frontend.css

I can see there's a responsive breakpoint where the label font size is reduced to 9px for smaller screens. Let me check what breakpoint this is:
Read frontend.css

Now let me find the first media query:
Grepped codebase for "@media"

Let me check the 768px breakpoint:
Read frontend.css

Perfect! Now I need to update the responsive font sizes to be proportionally larger. Let me update them:

    768px breakpoint: Currently 11px for nav-item and 10px for label
    480px breakpoint: Currently 10px for nav-item and 9px for label

Let me update these to be proportionally larger:
Replaced text 2 times

Now let me also update the plugin version to ensure the CSS changes take effect:
Replaced text
✅ DEFAULT FONT SIZE INCREASED!

Perfect! I've successfully increased the default font size for the bottom navigation. Here's what was changed:
📝 Changes Made:
✅ 1. Default Setting Updated:

// In includes/functions.php
'font_size' => '14',  // Changed from '12'

✅ 2. Base CSS Font Sizes:

/* Desktop/Default */
.wpbnp-nav-item {
    font-size: 14px;  /* Changed from 12px */
}

.wpbnp-nav-label {
    font-size: 14px;  /* Changed from 12px */
}

✅ 3. Responsive Font Sizes:

/* Tablet (768px and below) */
@media (max-width: 768px) {
    .wpbnp-nav-item {
        font-size: 13px;  /* Changed from 11px */
    }
    
    .wpbnp-nav-label {
        font-size: 12px;  /* Changed from 10px */
    }
}

/* Mobile (480px and below) */
@media (max-width: 480px) {
    .wpbnp-nav-item {
        font-size: 12px;  /* Changed from 10px */
    }
    
    .wpbnp-nav-label {
        font-size: 11px;  /* Changed from 9px */
    }
}

✅ 4. Version Bump:

define('WPBNP_VERSION', '1.0.2');  // Forces cache refresh

📱 Font Size Breakdown:

| Screen Size | Previous Size | New Size | Increase | |-------------|---------------|----------|----------| | Desktop | 12px | 14px | +2px (17% larger) | | Tablet | 11px | 13px | +2px (18% larger) | | Mobile | 10px | 12px | +2px (20% larger) | | Small Mobile | 9px | 11px | +2px (22% larger) |
🎯 Benefits:
✅ Better Readability:

    17-22% larger text across all devices
    Improved accessibility for users with vision difficulties
    Better mobile experience with more readable labels

✅ Consistent Scaling:

    Proportional increases across all breakpoints
    Maintains design harmony while improving readability
    Responsive design preserved

✅ User Experience:

    Easier to read navigation labels
    Better touch targets with slightly larger text
    Professional appearance maintained

🚀 Result:

The bottom navigation now has:

    ✅ Larger, more readable text labels
    ✅ Better accessibility compliance
    ✅ Improved mobile experience
    ✅ Consistent responsive scaling
    ✅ Professional appearance maintained

The changes will take effect after:

    Clearing browser cache (Ctrl+F5 or Cmd+Shift+R)
    Refreshing the WordPress page
    Existing users will see the new font size immediately

The font size is now more readable while maintaining the clean, professional look of the navigation! 📱✨