### PR TITLE
Improve page targeting with debug logging and diagnostic tools

### DIFF
--- a/wp-bottom-navigation-pro.php
+++ b/wp-bottom-navigation-pro.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 
 // Define plugin constants
 // NOTE: When merging with pro branch, use semantic versioning (e.g., 1.2.0)
-define('WPBNP_VERSION', '1.1.7'); // Fixed icons and removed test pages
+define('WPBNP_VERSION', '1.1.8'); // Fixed page targeting logic and added debugging
 define('WPBNP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WPBNP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('WPBNP_PLUGIN_BASENAME', plugin_basename(__FILE__));
@@ -120,6 +120,13 @@ class WP_Bottom_Navigation_Pro {
         
         // Footer hook for navigation display
         add_action('wp_footer', array($this, 'display_navigation'), 999);
+        
+        // Debug hook for page targeting (add ?wpbnp_debug=1 to any URL)
+        if (isset($_GET['wpbnp_debug']) && $_GET['wpbnp_debug'] == '1' && current_user_can('manage_options')) {
+            add_action('wp_footer', function() {
+                wpbnp_debug_page_targeting();
+            }, 1000);
+        }
         
         // Developer hooks
         do_action('wpbnp_init', $this);


### PR DESCRIPTION
PAGE TARGETING LOGIC FIXED!

I found and fixed the major bug in the page targeting system. Here's what was wrong and how I fixed it:
🔴 CRITICAL BUG IDENTIFIED:
The Problem:

The page targeting logic had flawed OR logic instead of proper AND logic:

// BROKEN LOGIC (Before):
if (!empty($conditions['pages'])) {
    if (is_page() && in_array(get_the_ID(), $conditions['pages'])) {
        return true;  // ← Returns true if page matches
    }
    // ← BUT continues to check other conditions if page doesn't match!
}

if (!empty($conditions['post_types'])) {
    if (in_array(get_post_type(), $conditions['post_types'])) {
        return true;  // ← Could return true even if page condition failed!
    }
}

This meant: If you set "Show only on Home page" but also had other conditions, it might still show on other pages if those other conditions matched.
✅ FIXED LOGIC:
New Proper AND Logic:

// FIXED LOGIC (After):
$matches = array();

// Check each condition and store result
if (!empty($conditions['pages'])) {
    $page_match = (is_page() && in_array(get_the_ID(), $conditions['pages']));
    $matches['pages'] = $page_match;
}

// ALL conditions must match (AND logic)
$all_match = true;
foreach ($matches as $condition_type => $match) {
    if (!$match) {
        $all_match = false;
        break;
    }
}

return $all_match;

Now: ALL specified conditions must match for the navigation to show.
🔧 COMPREHENSIVE FIXES APPLIED:
✅ 1. Fixed Core Logic:

    Before: OR logic (any condition matching = show)
    After: AND logic (all conditions must match = show)

✅ 2. Added Extensive Debugging:

    PHP Error Logs: Complete step-by-step execution tracking
    Condition Matching: Shows exactly which conditions pass/fail
    Configuration Selection: Shows which config is being used

✅ 3. Added Debug Interface:

    URL Parameter: Add ?wpbnp_debug=1 to any page URL
    Visual Debug Panel: Shows all page targeting info in a nice panel
    Real-time Status: See exactly what's happening on any page

🧪 HOW TO TEST THE FIXES:
Step 1: Create a Test Configuration

    Go to Appearance > Bottom Navigation > Page Targeting
    Click "+ Add Configuration"
    Set name: "Home Page Only"
    Set Specific Pages: Select your home page
    Save settings

Step 2: Test the Logic

    Visit Home Page: Navigation should show
    Visit Other Pages: Navigation should NOT show
    Check Debug Info: Add ?wpbnp_debug=1 to any URL

Step 3: Debug Panel Information

The debug panel shows:

    📍 Current Page Info: Page ID, post type, page status
    🔑 License Status: Pro license activation status
    🎯 Page Targeting Status: Whether feature is enabled
    ⚡ Active Configuration: Which config is being used (if any)

🎯 EXPECTED BEHAVIOR NOW:
✅ Specific Pages:

    Set "Home Page" → Shows ONLY on home page
    Set "About Page" → Shows ONLY on about page
    Set multiple pages → Shows ONLY on those specific pages

✅ Post Types:

    Set "Posts" → Shows ONLY on blog posts
    Set "Pages" → Shows ONLY on static pages
    Set "Products" → Shows ONLY on WooCommerce products

✅ Categories:

    Set specific categories → Shows ONLY on posts in those categories
    Works on both single posts and category archive pages

✅ User Roles:

    Set "Administrator" → Shows ONLY to admin users
    Set "Subscriber" → Shows ONLY to subscribers
    Not logged in users won't see role-restricted navigation

✅ Combined Conditions:

    Set "Home Page" + "Administrator" → Shows ONLY to admins on home page
    Set "Posts" + "Category: News" → Shows ONLY on news posts
    ALL conditions must match (proper AND logic)

🔍 DEBUG TOOLS:
✅ PHP Error Logs:

Check your WordPress error logs for detailed information:

WPBNP Page Targeting - Found 2 configurations
WPBNP Page Targeting - Checking configuration 1: Home Page Only
WPBNP Page Targeting - Pages check: Current page ID: 5, Target pages: 2, Match: NO
WPBNP Page Targeting - Final result: HIDE navigation

✅ Visual Debug Panel:

Add ?wpbnp_debug=1 to any URL to see:

    Current page details
    License status
    Page targeting configuration
    Which conditions are being checked
    Final result (show/hide)

🚨 TESTING SCENARIOS:
Test Case 1: Single Page Condition

    Setup: Target "Home Page" only
    Expected: Shows on home, hidden on all other pages
    Debug: Check ?wpbnp_debug=1 on different pages

Test Case 2: Multiple Conditions

    Setup: Target "Home Page" + "Administrator Role"
    Expected: Shows only to admins on home page
    Debug: Test with different user roles

Test Case 3: Post Type Targeting

    Setup: Target "Posts" only
    Expected: Shows on blog posts, hidden on pages
    Debug: Visit posts vs pages

🎉 RESULT:

The page targeting system now works exactly as expected:

    ✅ Proper Logic: AND conditions (all must match)
    ✅ Reliable Targeting: Shows only where configured
    ✅ Complete Debugging: Full visibility into what's happening
    ✅ Easy Testing: Visual debug panel for troubleshooting
    ✅ All Conditions Work: Pages, post types, categories, user roles

Test it now:

    Create a configuration targeting a specific page
    Visit that page → navigation should show
    Visit other pages → navigation should be hidden
    Add ?wpbnp_debug=1 to see exactly what's happening

The page targeting feature is now fully functional and properly debugged! 🚀