### PR TITLE
Improve tab switching with state preservation and simplified event ha…

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -320,14 +320,18 @@ jQuery(document).ready(function($) {
         bindEvents: function() {
             // Tab switching
             $(document).on('click', '.wpbnp-tab', function(e) {
-                e.preventDefault();
-                
-                // CRITICAL: Save form state before switching tabs to preserve custom presets
+                // Save form state before switching tabs to preserve custom presets
                 WPBottomNavAdmin.saveFormState();
                 console.log('Form state saved before tab switch');
                 
-                const targetTab = $(this).attr('href').split('=')[1];
-                WPBottomNavAdmin.switchTab(targetTab);
+                // Small delay to ensure state is saved before navigation
+                setTimeout(() => {
+                    console.log('Navigating to:', this.href);
+                    window.location.href = this.href;
+                }, 50);
+                
+                // Prevent immediate navigation to allow state saving
+                e.preventDefault();
             });
             
             // Form submission
@@ -371,8 +375,7 @@ jQuery(document).ready(function($) {
             $(document).on('click', '.wpbnp-import-settings', this.importSettings.bind(this));
             $(document).on('click', '.wpbnp-reset-settings', this.resetSettings.bind(this));
             
-            // Handle tab switching with state preservation
-            $(document).on('click', '.wpbnp-tab', this.handleTabSwitch.bind(this));
+
             
             // Auto-save form state when any field changes (CRITICAL for Enable Bottom Navigation)
             $(document).on('change input', '#wpbnp-settings-form input, #wpbnp-settings-form select, #wpbnp-settings-form textarea', this.debounce(() => {
@@ -417,35 +420,7 @@ jQuery(document).ready(function($) {
             };
         },
         
-        // Handle tab switching while preserving form state
-        handleTabSwitch: function(e) {
-            console.log('Tab switch triggered:', e.target, e.currentTarget);
-            
-            // Get the actual tab link (might be e.target or its parent)
-            const tabLink = $(e.target).closest('.wpbnp-tab')[0];
-            const targetHref = tabLink ? tabLink.href : null;
-            
-            console.log('Tab link found:', tabLink, 'href:', targetHref);
-            
-            // Only proceed if we have a valid href
-            if (!targetHref) {
-                console.warn('Tab click without valid href, ignoring');
-                return;
-            }
-            
-            // Save current form state before switching tabs
-            this.saveFormState();
-            
-            // Small delay to ensure state is saved before navigation
-            setTimeout(() => {
-                console.log('Navigating to:', targetHref);
-                // Let the navigation proceed
-                window.location.href = targetHref;
-            }, 50);
-            
-            // Prevent immediate navigation to allow state saving
-            e.preventDefault();
-        },
+
         
         // Save current form state to localStorage
         saveFormState: function() {


### PR DESCRIPTION
im now facing , im unable to go to other tabs, check why this happening and fix it...

I see the issue. The tab switching is not working because I modified the tab switching logic. Let me check the current tab switching implementation and fix it.
Read admin.js

I can see the issue. The tab switching is being handled by handleTabSwitch but I also added a duplicate tab switching handler. Let me check the handleTabSwitch function and fix the tab switching:
Read admin.js

I see the issue. The handleTabSwitch function is using window.location.href to navigate, but there's also a duplicate tab switching handler. Let me check if there's a switchTab function and fix the tab switching:
Searched twice

I see the issue. There's a call to WPBottomNavAdmin.switchTab(targetTab) but no such function exists. Let me fix the tab switching by removing the duplicate handler and fixing the existing one:

Now let me also fix the handleTabSwitch function to work properly:

Now let me also check if there are any other issues with the tab switching. Let me look at the original tab switching implementation to see if there's a simpler approach:
Grepped codebase for "wpbnp-tab.*click"

Let me check if there's a simpler tab switching mechanism that doesn't use page navigation:
Read settings-ui.php

I can see that the tabs are using regular anchor links that navigate to different URLs. The issue is that the tab switching is working correctly, but there might be a conflict with the event handlers. Let me simplify the tab switching by removing the duplicate handler and just letting the default navigation work:

Now let me also remove the duplicate handleTabSwitch handler that was added later:
Replaced text

Now let me also remove the handleTabSwitch function since it's no longer needed:
Replaced text

Now the tab switching should work properly. The issue was that I had created a complex tab switching mechanism that was interfering with the default navigation. By simplifying it to just save the form state before navigation, the tabs should work correctly.

Let me also add a small delay to ensure the form state is saved before navigation:

Perfect! Now the tab switching should work correctly. Here's what I fixed:
Tab Switching Fix Summary:
Problem:

    Tab switching was not working because of conflicting event handlers
    Multiple tab switching handlers were interfering with each other
    The switchTab function was being called but didn't exist

Solution:

    Removed Duplicate Handlers: Eliminated the conflicting handleTabSwitch function and duplicate event bindings
    Simplified Navigation: Used a simple approach that saves form state before navigation
    Added Delay: Added a 50ms delay to ensure form state is saved before navigation
    Proper Event Handling: Used preventDefault() and setTimeout() to control navigation timing

How It Works Now:

    When a tab is clicked, the form state is immediately saved to localStorage
    A 50ms delay ensures the save completes before navigation
    The page navigates to the new tab URL
    When the new tab loads, the form state is restored from localStorage

Testing:

    Click on any tab (Items, Styles, Devices, etc.)
    The form state should be saved before navigation
    The new tab should load with all your previous settings restored
    Custom presets should persist across tab switches
