### PR TITLE
Fix selector population with fallback methods and add delay

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1987,21 +1987,46 @@ jQuery(document).ready(function ($) {
                 console.log('Configuration added successfully');
                 console.log('Total configs now:', $('.wpbnp-config-item').length);
 
-                // Populate all selectors in the new configuration
-                const $newConfig = $('.wpbnp-config-item').last();
+                // Add a small delay to ensure DOM is fully rendered
+                setTimeout(() => {
+                    // Populate all selectors in the new configuration
+                    const $newConfig = $('.wpbnp-config-item').last();
 
                 // Populate custom presets
                 const newPresetSelector = $newConfig.find('.wpbnp-preset-selector');
                 console.log('New preset selector found:', newPresetSelector.length);
                 this.populatePresetSelector(newPresetSelector);
 
-                // Populate pages selector
-                const pagesSelector = $newConfig.find('select[name*="pages"]');
+                // Debug: Log the entire new config HTML
+                console.log('New config HTML:', $newConfig.html());
+                
+                // Populate pages selector - try multiple selector approaches
+                let pagesSelector = $newConfig.find('select[name*="pages"]');
+                if (!pagesSelector.length) {
+                    pagesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').includes('pages');
+                    });
+                }
+                if (!pagesSelector.length) {
+                    pagesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').indexOf('pages') !== -1;
+                    });
+                }
                 console.log('Pages selector found:', pagesSelector.length, pagesSelector.attr('name'));
                 this.populatePagesSelector(pagesSelector, configIndex);
 
-                // Populate categories selector  
-                const categoriesSelector = $newConfig.find('select[name*="categories"]');
+                // Populate categories selector - try multiple selector approaches
+                let categoriesSelector = $newConfig.find('select[name*="categories"]');
+                if (!categoriesSelector.length) {
+                    categoriesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').includes('categories');
+                    });
+                }
+                if (!categoriesSelector.length) {
+                    categoriesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').indexOf('categories') !== -1;
+                    });
+                }
                 console.log('Categories selector found:', categoriesSelector.length, categoriesSelector.attr('name'));
                 this.populateCategoriesSelector(categoriesSelector, configIndex);
                 console.log('Selector population completed');
@@ -2010,6 +2035,7 @@ jQuery(document).ready(function ($) {
                 this.saveFormState();
 
                 this.showNotification('New configuration added!', 'success');
+                }, 100); // 100ms delay
             } catch (error) {
                 console.error('Error adding configuration:', error);
                 this.showNotification('Error adding configuration: ' + error.message, 'error');


### PR DESCRIPTION
Pages selector not found for config 2 admin.js:3087:25
    populatePagesSelector http://localhost/wordpress/wp-content/plugins/WPBottomNav/assets/js/admin.js?ver=1.3.1:3087
    addPageTargetingConfig http://localhost/wordpress/wp-content/plugins/WPBottomNav/assets/js/admin.js?ver=1.3.1:2001
    initProFeatures http://localhost/wordpress/wp-content/plugins/WPBottomNav/assets/js/admin.js?ver=1.3.1:1853
    jQuery 10
        dispatch
        handle
    (Async: EventListener.handleEvent)
        add
        <anonymous>
        t
        Le
        each
        each
        Le
        on
    init http://localhost/wordpress/wp-admin/js/common.min.js?ver=6.8.2:2
    <anonymous> http://localhost/wordpress/wp-admin/js/common.min.js?ver=6.8.2:2
    jQuery 13
        e
        t
    (Async: setTimeout handler)
        l
        c
        fireWith
        fire
        c
        fireWith
        ready
        P
    (Async: EventListener.handleEvent)
        <anonymous>
        <anonymous>
        <anonymous>
Categories selector found: 0 undefined admin.js:2005:25
