### PR TITLE
Improve selector finding for pages and categories in admin config

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1986,15 +1986,25 @@ jQuery(document).ready(function ($) {
                     this.populatePresetSelector(newPresetSelector);
                 }
 
-                // Populate pages selector
-                const pagesSelector = $newConfig.find('select[name*="pages"]');
+                // Populate pages selector - try multiple selector approaches
+                let pagesSelector = $newConfig.find('select[name*="pages"]');
+                if (!pagesSelector.length) {
+                    pagesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').includes('pages');
+                    });
+                }
                 console.log('Pages selector found:', pagesSelector.length, 'Name:', pagesSelector.attr('name'));
                 if (pagesSelector.length > 0) {
                     this.populatePagesSelector(pagesSelector, configIndex);
                 }
 
-                // Populate categories selector  
-                const categoriesSelector = $newConfig.find('select[name*="categories"]');
+                // Populate categories selector - try multiple selector approaches
+                let categoriesSelector = $newConfig.find('select[name*="categories"]');
+                if (!categoriesSelector.length) {
+                    categoriesSelector = $newConfig.find('select').filter(function() {
+                        return $(this).attr('name') && $(this).attr('name').includes('categories');
+                    });
+                }
                 console.log('Categories selector found:', categoriesSelector.length, 'Name:', categoriesSelector.attr('name'));
                 if (categoriesSelector.length > 0) {
                     this.populateCategoriesSelector(categoriesSelector, configIndex);


### PR DESCRIPTION
Now try adding a new configuration again. This should find the selectors using the .filter() method which is more reliable for complex name attributes with square brackets.

The console should now show:

    "Pages selector found: 1 Name: settings[page_targeting][configurations][0][conditions][pages][]"
    "Categories selector found: 1 Name: settings[page_targeting][configurations][0][conditions][categories][]"
