### PR TITLE
Remove include disabled items feature and update preset modal UI

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1921,7 +1921,7 @@ input:checked + .wpbnp-toggle-slider:before {
     opacity: 1 !important;
     position: relative !important;
     z-index: 1 !important;
-    border: 2px solid red !important; /* Debug border */
+
 }
 
 #wpbnp-create-preset-modal .wpbnp-form-group,
@@ -1936,7 +1936,7 @@ input:checked + .wpbnp-toggle-slider:before {
     opacity: 1 !important;
     position: relative !important;
     z-index: 2 !important;
-    border: 2px solid blue !important; /* Debug border */
+
 }
 
 #wpbnp-create-preset-modal .wpbnp-form-group label,
@@ -1958,7 +1958,7 @@ input:checked + .wpbnp-toggle-slider:before {
     position: relative !important;
     z-index: 3 !important;
     width: 100% !important;
-    border: 2px solid green !important; /* Debug border */
+
 }
 
 #wpbnp-create-preset-modal .wpbnp-form-group input[type="text"],


### PR DESCRIPTION
 Fixed Issues:
1. Simplified Create Modal:

    ✅ Removed the "Include disabled items" checkbox section
    ✅ Removed unnecessary complexity
    ✅ Now shows all current navigation items by default
    ✅ Cleaner, simpler interface

2. Fixed Edit Preset Modal:

    ✅ Now shows the actual saved items from the preset instead of current navigation items
    ✅ Added updateEditPresetItemsPreview() function to display saved items
    ✅ Modified initEditPresetModal() to populate with saved data
    ✅ Changed label from "Current Preset Info" to "Saved Navigation Items"
    ✅ Shows the correct count of saved items

3. Technical Improvements:

    ✅ Removed debug borders for clean design
    ✅ Simplified item filtering logic
    ✅ Better data handling between create and edit modes
    ✅ Proper separation of current items vs saved items

How it works now:

    Create Preset Modal:
        Shows current navigation items
        Simple form with name and description
        No complex options

    Edit Preset Modal:
        Shows the actual saved items from the preset
        Displays the correct count
        Shows the real data that was saved

The key fix was that the edit modal now reads the saved items from the hidden input field (input[name*="[items]"]) and displays those instead of trying to show current navigation items.