### PR TITLE
Add debug logging for navigation item collection and preset creation

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2675,7 +2675,10 @@ jQuery(document).ready(function ($) {
 
             // Get current navigation items
             const currentItems = this.getCurrentNavigationItems();
+            console.log('handleCreatePresetSubmit: Current items collected:', currentItems);
+            
             const itemsToInclude = currentItems; // Include all items
+            console.log('handleCreatePresetSubmit: Items to include in preset:', itemsToInclude);
 
             if (itemsToInclude.length === 0) {
                 this.showNotification('No items to include in the preset. Please add some navigation items first.', 'error');
@@ -2733,14 +2736,32 @@ jQuery(document).ready(function ($) {
         // Get current navigation items
         getCurrentNavigationItems: function () {
             const items = [];
-            $('#wpbnp-items-list .wpbnp-nav-item-row').each(function () {
+            console.log('getCurrentNavigationItems: Starting to collect items...');
+            console.log('Total .wpbnp-nav-item-row elements found:', $('#wpbnp-items-list .wpbnp-nav-item-row').length);
+            
+            $('#wpbnp-items-list .wpbnp-nav-item-row').each(function (index) {
                 const $row = $(this);
+                const enabledInput = $row.find('input[name*="[enabled]"]');
+                // For hidden inputs, check the value instead of :checked
+                const enabledValue = enabledInput.attr('type') === 'hidden' ? 
+                    enabledInput.val() === '1' : 
+                    enabledInput.is(':checked');
+                
+                console.log(`Item ${index + 1}:`, {
+                    id: $row.find('input[name*="[id]"]').val(),
+                    label: $row.find('input[name*="[label]"]').val(),
+                    enabled: enabledValue,
+                    enabledInputType: enabledInput.attr('type'),
+                    enabledInputValue: enabledInput.val(),
+                    enabledInputChecked: enabledInput.is(':checked')
+                });
+                
                 const item = {
                     id: $row.find('input[name*="[id]"]').val() || 'item_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9),
                     label: $row.find('input[name*="[label]"]').val() || '',
                     icon: $row.find('input[name*="[icon]"]').val() || '',
                     url: $row.find('input[name*="[url]"]').val() || '',
-                    enabled: $row.find('input[name*="[enabled]"]').is(':checked'),
+                    enabled: enabledValue,
                     target: $row.find('select[name*="[target]"]').val() || '_self',
                     show_badge: $row.find('input[name*="[show_badge]"]').is(':checked'),
                     badge_type: $row.find('select[name*="[badge_type]"]').val() || 'count',
@@ -2756,12 +2777,15 @@ jQuery(document).ready(function ($) {
                 items.push(item);
             });
 
+            console.log('getCurrentNavigationItems: Final items collected:', items);
             return items;
         },
 
         // Add preset to DOM with unique ID management
         addPresetToDOM: function (preset) {
             console.log('addPresetToDOM called for preset:', preset.name);
+            console.log('addPresetToDOM: Preset items:', preset.items);
+            console.log('addPresetToDOM: Items enabled states:', preset.items.map(item => ({ id: item.id, label: item.label, enabled: item.enabled })));
             
             const presetsContainer = $('#wpbnp-custom-presets-list');
             const noPresetsMessage = presetsContainer.find('.wpbnp-no-presets');


### PR DESCRIPTION
FIXED THE CUSTOM PRESET ENABLED STATE ISSUE!
🔍 Root Cause Analysis:

The issue was in the getCurrentNavigationItems function:

    Wrong input type check: The function was using :checked for all enabled inputs
    Hidden input mismatch: The enabled state is stored in a hidden input with value '1' or '0', not a checkbox
    Incorrect reading: Using :checked on a hidden input always returns false

✅ Complete Solution Implemented:
1. Fixed Enabled State Reading - FIXED

// BEFORE (WRONG):
enabled: $row.find('input[name*="[enabled]"]').is(':checked'),

// AFTER (CORRECT):
const enabledInput = $row.find('input[name*="[enabled]"]');
const enabledValue = enabledInput.attr('type') === 'hidden' ? 
    enabledInput.val() === '1' : 
    enabledInput.is(':checked');

2. Enhanced Debugging - ADDED

console.log(`Item ${index + 1}:`, {
    id: $row.find('input[name*="[id]"]').val(),
    label: $row.find('input[name*="[label]"]').val(),
    enabled: enabledValue,
    enabledInputType: enabledInput.attr('type'),
    enabledInputValue: enabledInput.val(),
    enabledInputChecked: enabledInput.is(':checked')
});

3. Comprehensive Logging - ADDED

console.log('getCurrentNavigationItems: Starting to collect items...');
console.log('getCurrentNavigationItems: Final items collected:', items);
console.log('handleCreatePresetSubmit: Current items collected:', currentItems);
console.log('addPresetToDOM: Items enabled states:', preset.items.map(item => ({ id: item.id, label: item.label, enabled: item.enabled })));

🔄 How It Works Now:

    User toggles item state → Hidden input value changes to '1' or '0'
    Create custom preset → getCurrentNavigationItems reads correct enabled state
    Preset saved → Items maintain their actual enabled/disabled state
    Preset displayed → Shows correct enabled/disabled state in preview

🎯 The Complete Fix:

    ✅ Fixed enabled state reading for hidden inputs
    ✅ Added comprehensive debugging to track the process
    ✅ Maintained compatibility with checkbox inputs (if any)
    ✅ Enhanced logging for troubleshooting
    ✅ Preserved actual item states in custom presets

🧪 Testing:

Now when you:

    Create navigation items in the main Items tab
    Toggle some items to disabled
    Create a custom preset
    The preset should save the actual enabled/disabled state of each item

The debugging logs will show:

    Each item's enabled state being read correctly
    The final items array with proper enabled states
    The preset being saved with correct item states
